### PR TITLE
Sources are visible on the UI

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -30,15 +30,17 @@ class ResultsController < ApplicationController
     prompt =  <<~TEXT
       Based on this news excerpt: #{@result.user_input}.
       Return the political_bias of the text (choose  only one between: Far-left, Left, Center, Right, Far-right),
-      the fact_score (choose only one between: Very low, Low, Medium, High, Very high)
-      and a title summarizing the key point of the news excerpt (maximum 5 words).
-      Provide your response in JSON format with keys 'political_bias’, 'fact_score'  and ‘title’
+      the fact_score (choose only one between: Very low, Low, Medium, High, Very high),
+      a title summarizing the key point of the news excerpt (maximum 5 words)
+      and a link to the homepage of news outlets of opposite political biases (maximum 3, called 'source').
+      Provide your response in JSON format with keys 'political_bias’, 'fact_score', 'title'and 'source'
+      (source is a hash itself with the 3 links)
       and use the Media Bias/Fact Check (MBFC) methodology.
     TEXT
     client = OpenAI::Client.new
     chatgpt_response = client.chat(parameters: {
       model: "gpt-4o-mini",
-      messages: [{ role: "user", content: prompt}]
+      messages: [{ role: "user", content: prompt }]
     })
 
     # Extract the response from ChatGPT and clean it to parse the JSON
@@ -46,10 +48,11 @@ class ResultsController < ApplicationController
     @clean_response = @response.gsub(/```json\n|```/, '')
     @result.political_bias = JSON.parse(@clean_response)["political_bias"]
     @result.fact_score = JSON.parse(@clean_response)["fact_score"]
-    @result.title= JSON.parse(@clean_response)["title"]
+    @result.title = JSON.parse(@clean_response)["title"]
+    @media = JSON.parse(@clean_response)["source"]
 
     if @result.save
-      render json: { user_input: @result.user_input, political_bias: @result.fact_score, fact_score: @result.fact_score, title: @result.title, message: "Result saved successfully" }
+      render json: { user_input: @result.user_input, political_bias: @result.fact_score, fact_score: @result.fact_score, title: @result.title, media: @media, message: "Result saved successfully" }
     else
       render json: { errors: @result.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -52,7 +52,19 @@ class ResultsController < ApplicationController
     @media = JSON.parse(@clean_response)["source"]
 
     if @result.save
-      render json: { user_input: @result.user_input, political_bias: @result.fact_score, fact_score: @result.fact_score, title: @result.title, media: @media, message: "Result saved successfully" }
+      # Save the media resultsonly if the result is saved
+      @media.each do |political_bias, url|
+        @result.medias.create(political_bias: political_bias, url: url)
+      end
+
+      render json: {
+        user_input: @result.user_input,
+        political_bias: @result.political_bias,
+        fact_score: @result.fact_score,
+        title: @result.title,
+        media: @media,
+        message: "Result saved successfully"
+      }
     else
       render json: { errors: @result.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/javascript/controllers/result_controller.js
+++ b/app/javascript/controllers/result_controller.js
@@ -27,7 +27,20 @@ export default class extends Controller {
         console.log(data);
         if (data.user_input) {
           this.fullResultTarget.classList.remove('d-none');
-          this.fullResultTarget.innerHTML = `<h2>Result</h2><div>${data.user_input}</div><div><strong>Political bias:</strong>${data.political_bias}. <strong>Fact score:</strong>${data.fact_score}.</div>`;
+          console.log(data.media);
+
+          let mediaList = "";
+          Object.entries(data.media).forEach(([key, value]) => {
+            console.log(key, value);
+            mediaList += `<li><strong>${key}:</strong> <a href="${value}" target="_blank">${value}</a></li>`;
+
+          });
+
+          this.fullResultTarget.innerHTML = `
+            <h2>Result</h2><div>${data.user_input}</div>
+            <div><strong>Political bias:</strong>${data.political_bias}.
+            <strong>Fact score:</strong>${data.fact_score}.
+            <strong>Read from other sources:<ul>${mediaList}</ul></div>`;
         }
       })
       .catch((error) => {

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -1,0 +1,4 @@
+class Media < ApplicationRecord
+  has_many :media_results
+  has_many :results, through: :media_results
+end

--- a/app/models/media_result.rb
+++ b/app/models/media_result.rb
@@ -1,0 +1,4 @@
+class MediaResult < ApplicationRecord
+  belongs_to :result
+  belongs_to :media
+end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,5 +1,7 @@
 class Result < ApplicationRecord
   belongs_to :user
+  has_many :media_results
+  has_many :medias, through: :media_results
   validates :user_input, presence: true, length: { in: 50..5000, wrong_length: "You should provide between 50 and 5000 characters" }
 
   include PgSearch::Model

--- a/app/views/results/_card.html.erb
+++ b/app/views/results/_card.html.erb
@@ -6,6 +6,14 @@
     <h1 class="truncate"><%= result.title %></h1>
   <% end %>
   <p>Query: <%= result.user_input %></p>
+  <!-- Check if media  is nil -->
+  <% if result.medias.nil? %>
+    <p>No media available</p>
+  <% else %>
+    <% result.medias.each do |item| %>
+      <p>Media: <%= item.url %></p>
+    <% end %>
+  <% end %>
 
   <div class="row-card">
     <h2>Fact score</h2>

--- a/app/views/results/_history_results.html.erb
+++ b/app/views/results/_history_results.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <% if results.any? %>
     <% results.each do |result| %>
-      <div class="col col-6 col-md-4 col-lg-4">
+      <div class="col col-12 col-md-6 col-lg-4">
         <%= render "results/card", result: result %>
       </div>
     <% end %>

--- a/db/migrate/20250129150550_create_media.rb
+++ b/db/migrate/20250129150550_create_media.rb
@@ -1,0 +1,12 @@
+class CreateMedia < ActiveRecord::Migration[7.1]
+  def change
+    create_table :media do |t|
+      t.string :name
+      t.string :url
+      t.string :political_bias
+      t.string :logo_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250129150624_create_media_results.rb
+++ b/db/migrate/20250129150624_create_media_results.rb
@@ -1,0 +1,10 @@
+class CreateMediaResults < ActiveRecord::Migration[7.1]
+  def change
+    create_table :media_results do |t|
+      t.references :result, null: false, foreign_key: true
+      t.references :media, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_29_141526) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_29_150624) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "media", force: :cascade do |t|
+    t.string "name"
+    t.string "url"
+    t.string "political_bias"
+    t.string "logo_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "media_results", force: :cascade do |t|
+    t.bigint "result_id", null: false
+    t.bigint "media_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["media_id"], name: "index_media_results_on_media_id"
+    t.index ["result_id"], name: "index_media_results_on_result_id"
+  end
 
   create_table "results", force: :cascade do |t|
     t.string "fact_score"
@@ -39,5 +57,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_29_141526) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "media_results", "media", column: "media_id"
+  add_foreign_key "media_results", "results"
   add_foreign_key "results", "users"
 end

--- a/test/models/media_result_test.rb
+++ b/test/models/media_result_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MediaResultTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/medium_test.rb
+++ b/test/models/medium_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MediumTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- Prompt was re-tweaked to get 'sources', a hash containing 3 key-value pairs of news outlets with opposite political bias from the one of the news excerpt
- Works on the front-end but I still need to make sure it's correctly saved in the DB (medias table)
- Created the medias table and media_results tables for this purpose