### PR TITLE
fix user association to the search query

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -56,8 +56,9 @@ class ResultsController < ApplicationController
   end
 
   def create
+
     # Conditional so we do not have to login in the plugin, so we assign a specific user to be the plugin_user
-    user = request.format.json? ? User.extension_user : current_user
+    user = request.headers["X-Requested-By"] == "ChromeExtension" ? User.extension_user : current_user
     @result = OpenAiCallJob.perform_now(result_params, user)
 
     respond_to do |format|

--- a/public/chrome_extension/scripts/popup.js
+++ b/public/chrome_extension/scripts/popup.js
@@ -37,7 +37,7 @@ function getResults(userInput) {
   fetch(form.action, {
     method: "POST",
     mode: "no-cors",
-    headers: { "Accept": "application/json" },
+    headers: { "Accept": "application/json", "X-Requested-By": "ChromeExtension" },
     body: new FormData(form)
   })
     .then(response => response.json())


### PR DESCRIPTION
- add custom header to the request from the extension
- use this header to properly differenciate users from app and users from extension